### PR TITLE
fix: Can't run the tool with a Windows task, we must check if input has been redirected

### DIFF
--- a/TfsWorkspacesCleaner/Cleaner.cs
+++ b/TfsWorkspacesCleaner/Cleaner.cs
@@ -58,7 +58,7 @@ namespace TfsWorkspacesCleaner
             {
                 try
                 {
-                    if (Console.KeyAvailable)
+                    if (!Console.IsInputRedirected && Console.KeyAvailable)
                     {
                         var keyPressed = Console.ReadKey(true);
                         ConsoleLogger.Write(ConsoleColor.Yellow, "Paused. Enter 'q' to quit processing or any other key to resume: ");


### PR DESCRIPTION
When the tool is started from a Windows task we get this error :

An error occurred while processing workspace "ws_46_5":
System.InvalidOperationException: Cannot see if a key has been pressed
when either application does not have a console or when console input
has been redirected from a file. Try Console.In.Peek.
at System.Console.get_KeyAvailable()
at TfsWorkspacesCleaner.Cleaner.Execute() in
TfsWorkspacesCleaner\Cleaner.cs:line 61

To fix this issue we must test if the input as been redirected [more
info](http://stackoverflow.com/questions/3961542/checking-standard-input-in-c-sharp)
in Cleaner.Execute where we can can quit the processing.